### PR TITLE
GD-4: Add GdUnit3 version validation before activate the extension

### DIFF
--- a/src/GdUnit3Version.ts
+++ b/src/GdUnit3Version.ts
@@ -1,0 +1,58 @@
+import path = require("path");
+import { Uri, workspace } from "vscode";
+
+export class GdUnit3Version {
+    private _major: number;
+    private _minor: number;
+    private _patch: number;
+
+    constructor(major: number, minor: number, patch: number) {
+        this._major = major;
+        this._minor = minor;
+        this._patch = patch;
+    }
+
+    public static parse(version: string): GdUnit3Version {
+        const parts = version.trim().replace(/"/g, '').split('.');
+        return new GdUnit3Version(parseInt(parts[0]), parseInt(parts[1]), parseInt(parts[2]));
+    }
+
+    public isLessThan(other: GdUnit3Version | undefined): boolean {
+        if (other == undefined) {
+            return false;
+        }
+        const v1 = [this._major, this._minor, this._patch];
+        const v2 = [other._major, other._minor, other._patch];
+        for (let i = 0; i < v1.length; i++) {
+            if (v1[i] > v2[i]) {
+                return true;
+            }
+            if (v1[i] < v2[i]) {
+                return false;
+            }
+        }
+        return false;
+    }
+
+    public toString(): string {
+        return `v${this._major}.${this._minor}.${this._patch}`;
+    }
+}
+
+export async function getGdUnit3Version(): Promise<GdUnit3Version | undefined> {
+    console.log('Scanning GdUnit plugin version.');
+    const folders = workspace.workspaceFolders;
+    const projectUri = folders ? folders[0].uri : Uri.file("invalid");
+    const pluginConf = path.resolve(projectUri.fsPath, 'addons/gdUnit3/plugin.cfg');
+    return await workspace.openTextDocument(Uri.file(pluginConf))
+        .then(document => {
+            for (let i = 0; i < document.lineCount; i++) {
+                const text = document.lineAt(i).text
+                if (text.startsWith("version")) {
+                    const version = text.split('=')[1];
+                    return GdUnit3Version.parse(version);
+                }
+            }
+            return undefined;
+        });
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,16 +1,32 @@
 
-import { ExtensionContext } from 'vscode';
+import { ExtensionContext, window } from 'vscode';
 import { CommandHandler } from './commandHandler';
 import { GdUnitEvent } from './gdUnitEvent';
 import { TestEventServer } from "./network/testEventServer";
 import { ReportView } from "./ui/parts/reportView";
 import { TestTreeExplorer } from "./ui/treeExplorer";
+import { getGdUnit3Version, GdUnit3Version } from './GdUnit3Version';
 
-export function activate(context: ExtensionContext) {
+
+const MIN_REQUIRED_GDUNIT_VERSION = new GdUnit3Version(2, 2, 0);
+
+export async function activate(context: ExtensionContext) {
+
+	await getGdUnit3Version().then(version => {
+		if (MIN_REQUIRED_GDUNIT_VERSION.isLessThan(version)) {
+			window.showErrorMessage(`This extension requires GdUnit3 minimum version ${MIN_REQUIRED_GDUNIT_VERSION} but found ${version}.`);
+			throw new Error('Invalid GdUnit3 Version found!');
+		}
+		console.info(`GdUnit3 ${version} found.`)
+	});
 
 	const reportView = new ReportView(context);
 	const treeExplorer = new TestTreeExplorer(context, reportView);
 	const commandHandler = new CommandHandler(context);
+	const testEventServer = new TestEventServer()
+		.on('message', (message) => treeExplorer.listen(message))
+		.on('event', (event) => treeExplorer.listen(event))
+		.on('test_suite', (testSuite) => treeExplorer.listen(testSuite))
 
 	commandHandler.onGdUnitEvent((event: GdUnitEvent) => {
 		treeExplorer.listen(event);
@@ -18,14 +34,15 @@ export function activate(context: ExtensionContext) {
 
 	context.subscriptions.push(
 		commandHandler,
-		new TestEventServer()
-			.on('message', (message) => treeExplorer.listen(message))
-			.on('event', (event) => treeExplorer.listen(event))
-			.on('test_suite', (testSuite) => treeExplorer.listen(testSuite)),
+		testEventServer,
 		treeExplorer,
 		reportView
 	);
 	console.log('"GdUnit3 Test Explorer" is now active!');
 }
 
-export function deactivate() { }
+export function deactivate(): void {
+	console.log('"GdUnit3 Test Explorer" is now deactived!');
+	// TODO hide from activiy bar
+	//commands.executeCommand('editor.action.addCommentLine');
+}

--- a/src/testRunner.ts
+++ b/src/testRunner.ts
@@ -3,6 +3,7 @@ import { debug, OutputChannel, Position, Range, Uri, ViewColumn, window, workspa
 import { CommandHandler } from './commandHandler';
 import { GdUnitSettings } from './gdUnitSettings';
 import { TestRunnerConfiguration } from './testRunnerConfiguration';
+import path = require("path");
 
 export class TestRunner {
     private _workspaceFolder: WorkspaceFolder | undefined = undefined;
@@ -141,7 +142,7 @@ export class TestRunner {
             .then<string | undefined>(entries =>
                 entries.filter(entry => entry[0].endsWith('.csproj')).map(e => e[0]).shift()
             );
-        return path.join(this.projectUri.fsPath, projectFile ?  projectFile: '');
+        return path.join(this.projectUri.fsPath, projectFile ? projectFile : '');
     }
 
     private debugConfig() {


### PR DESCRIPTION
- we needs to check the GdUnit3 version beause with v2.2.0 we switch to .Net6
- fix missing path import on testRunner