### PR TITLE
GD-13: Fix generate test case on linux systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ This extension provides an inspector to run and debug your GdUnit3 c# tests in V
 ![Screenshot](resources/vsc-extension.png)
 
 ## Release Notes
+
+### Version 2.2.4
+- Fixed create test was failing on linux systems
+
 ### 2.2.3 (HotFix)
 * Fixed failing test generation (works now with and without namespaces)
 * Changed minimum required GdUnit3 plugin to v2.2.3

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "gdunit3",
 	"displayName": "Godot GdUnit Test Explorer",
 	"description": "Test Explorer for GdUnit3",
-	"version": "2.2.3",
+	"version": "2.2.4",
 	"publisher": "mikeschulze",
 	"license": "MIT",
 	"repository": {

--- a/src/testRunner.ts
+++ b/src/testRunner.ts
@@ -108,11 +108,17 @@ export class TestRunner {
                 process.stdout?.on('data', (stream) => {
                     const line = `${stream}`;
                     if (line.includes('JSON_RESULT:')) {
-                        result = rExp.exec(line)?.at(2);
+                        try {
+                            const r = rExp.exec(line) as RegExpExecArray;
+                            result = r[2];
+                        }
+                        catch(err) {
+                            console.error(err);
+                        }
                     }
                 });
                 process.stderr?.on('data', (stream) => console.debug(`ERR: ${stream}`));
-                process.on('close', async (code, signal) => {
+                process.on('close', async (code) => {
                     if (code == 0 && result != undefined) {
                         type Test = { line: number; path: string; }
                         type Response = { TestCases: Array<Test>; }


### PR DESCRIPTION
- the generate tests was failing by parsing the result of the generate process
- bump to version v2.2.4